### PR TITLE
View entry

### DIFF
--- a/lib/e_chronicler/models/journal_entry.ex
+++ b/lib/e_chronicler/models/journal_entry.ex
@@ -44,10 +44,6 @@ defmodule EChronicler.Models.JournalEntry do
 
   def get_journal_entry(id) do
     Repo.get(JournalEntry, id)
-    |> case do
-      nil -> "no entry found"
-      %JournalEntry{} -> %JournalEntry{}
-    end
   end
 
 end

--- a/lib/e_chronicler/models/journal_entry.ex
+++ b/lib/e_chronicler/models/journal_entry.ex
@@ -42,12 +42,6 @@ defmodule EChronicler.Models.JournalEntry do
     |> Repo.insert()
   end
 
-  def get_journal_entry(id) do
-    Repo.get(JournalEntry, id)
-    |> case do
-      nil -> "no entry found"
-      %JournalEntry{} -> %JournalEntry{}
-    end
-  end
+  def get_journal_entry(id), do: Repo.get(JournalEntry, id)
 
 end

--- a/lib/e_chronicler/models/journal_entry.ex
+++ b/lib/e_chronicler/models/journal_entry.ex
@@ -42,6 +42,12 @@ defmodule EChronicler.Models.JournalEntry do
     |> Repo.insert()
   end
 
-  def get_journal_entry!(id), do: Repo.get!(JournalEntry, id)
+  def get_journal_entry(id) do
+    Repo.get(JournalEntry, id)
+    |> case do
+      nil -> "no entry found"
+      %JournalEntry{} -> %JournalEntry{}
+    end
+  end
 
 end

--- a/lib/e_chronicler/models/journal_entry.ex
+++ b/lib/e_chronicler/models/journal_entry.ex
@@ -42,4 +42,6 @@ defmodule EChronicler.Models.JournalEntry do
     |> Repo.insert()
   end
 
+  def get_journal_entry!(id), do: Repo.get!(JournalEntry, id)
+
 end

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -10,8 +10,10 @@ defmodule EChroniclerWeb.JournalEntryController do
   end
 
   def show(conn, %{"id" => id}) do
-    entry = JournalEntry.get_journal_entry(id)
-    render(conn, "show.html", entry: entry)
+    case JournalEntry.get_journal_entry(id) do
+      nil -> render(conn, "404.html")
+      entry -> render(conn, "show.html", entry: entry)
+    end
   end
 
 

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -12,8 +12,10 @@ defmodule EChroniclerWeb.JournalEntryController do
   def show(conn, %{"id" => id}) do
     case JournalEntry.get_journal_entry(id) do
       nil ->
-        put_view(conn, EChroniclerWeb.ErrorView)
-        |> render("404.html")
+        conn
+        |> put_status(:not_found)
+        |> put_view(EChroniclerWeb.ErrorView)
+        |> render(:"404")
       entry -> render(conn, "show.html", entry: entry)
     end
   end

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -10,9 +10,12 @@ defmodule EChroniclerWeb.JournalEntryController do
   end
 
   def show(conn, %{"id" => id}) do
-    entry = JournalEntry.get_journal_entry(id)
-    render(conn, "show.html", entry: entry)
+    case JournalEntry.get_journal_entry(id) do
+      nil ->
+        put_view(conn, EChroniclerWeb.ErrorView)
+        |> render("404.html")
+      entry -> render(conn, "show.html", entry: entry)
+    end
   end
-
 
 end

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -8,4 +8,10 @@ defmodule EChroniclerWeb.JournalEntryController do
     render(conn, "index.html", journal_entries: journal_entries)
   end
 
+  def show(conn, %{"id" => id}) do
+    entry = Timeline.get_entry!(id)
+    render(conn, "show.html", entry: entry)
+  end
+
+
 end

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -2,6 +2,7 @@ defmodule EChroniclerWeb.JournalEntryController do
   use EChroniclerWeb, :controller
 
   alias EChronicler.JournalEntries
+  alias EChronicler.Models.JournalEntry
 
   def index(conn, _params) do
     journal_entries = JournalEntries.list_journal_entries()
@@ -9,7 +10,7 @@ defmodule EChroniclerWeb.JournalEntryController do
   end
 
   def show(conn, %{"id" => id}) do
-    entry = Timeline.get_entry!(id)
+    entry = JournalEntry.get_journal_entry!(id)
     render(conn, "show.html", entry: entry)
   end
 

--- a/lib/e_chronicler_web/controllers/journal_entry_controller.ex
+++ b/lib/e_chronicler_web/controllers/journal_entry_controller.ex
@@ -10,7 +10,7 @@ defmodule EChroniclerWeb.JournalEntryController do
   end
 
   def show(conn, %{"id" => id}) do
-    entry = JournalEntry.get_journal_entry!(id)
+    entry = JournalEntry.get_journal_entry(id)
     render(conn, "show.html", entry: entry)
   end
 

--- a/lib/e_chronicler_web/router.ex
+++ b/lib/e_chronicler_web/router.ex
@@ -18,6 +18,7 @@ defmodule EChroniclerWeb.Router do
     pipe_through :browser
 
     get "/", JournalEntryController, :index
+    get "/:id", JournalEntryController, :show
   end
 
   # Other scopes may use custom stacks.

--- a/lib/e_chronicler_web/templates/error/404.html.heex
+++ b/lib/e_chronicler_web/templates/error/404.html.heex
@@ -1,0 +1,1 @@
+<h1> The page you are looking for could not be found. Sorry! </h1>

--- a/lib/e_chronicler_web/templates/journal_entry/index.html.heex
+++ b/lib/e_chronicler_web/templates/journal_entry/index.html.heex
@@ -1,10 +1,9 @@
 <h1>Journal Entries Page</h1>
 
 <div>
- <a href="/post">New post</a>
     <%= for journal_entry <- @journal_entries do %>
       <div id="entry">
-        <a href="/{journal_entry.id}"> <h3>Title: <%= journal_entry.title %></h3></a>
+       <h3> <%= link journal_entry.title, to: "/#{journal_entry.id}" %> </h3>
         Author: <%= journal_entry.author %> <br>
         Published: <%= journal_entry |> EChronicler.Models.JournalEntry.format_datetime() %> <br>
         Entry: <%= journal_entry.entry |> EChronicler.Models.JournalEntry.truncate_journal_entry_text() %>

--- a/lib/e_chronicler_web/templates/journal_entry/index.html.heex
+++ b/lib/e_chronicler_web/templates/journal_entry/index.html.heex
@@ -4,7 +4,7 @@
  <a href="/post">New post</a>
     <%= for journal_entry <- @journal_entries do %>
       <div id="entry">
-        <a href=""> <h3>Title: <%= journal_entry.title %></h3></a>
+        <a href="/{journal_entry.id}"> <h3>Title: <%= journal_entry.title %></h3></a>
         Author: <%= journal_entry.author %> <br>
         Published: <%= journal_entry |> EChronicler.Models.JournalEntry.format_datetime() %> <br>
         Entry: <%= journal_entry.entry |> EChronicler.Models.JournalEntry.truncate_journal_entry_text() %>

--- a/lib/e_chronicler_web/templates/journal_entry/index.html.heex
+++ b/lib/e_chronicler_web/templates/journal_entry/index.html.heex
@@ -1,10 +1,10 @@
 <h1>Journal Entries Page</h1>
 
 <div>
- 
+ <a href="/post">New post</a>
     <%= for journal_entry <- @journal_entries do %>
       <div id="entry">
-        <h3>Title: <%= journal_entry.title %></h3>
+        <a href=""> <h3>Title: <%= journal_entry.title %></h3></a>
         Author: <%= journal_entry.author %> <br>
         Published: <%= journal_entry |> EChronicler.Models.JournalEntry.format_datetime() %> <br>
         Entry: <%= journal_entry.entry |> EChronicler.Models.JournalEntry.truncate_journal_entry_text() %>

--- a/lib/e_chronicler_web/templates/journal_entry/show.html.heex
+++ b/lib/e_chronicler_web/templates/journal_entry/show.html.heex
@@ -1,0 +1,12 @@
+
+
+<div>
+      <div id="entry">
+        <h3>Title: <%= @entry.title %></h3>
+        Author: <%= @entry.author %> <br>
+        Published: <%= @entry |> EChronicler.Models.JournalEntry.format_datetime() %> <br>
+        Entry: <%= @entry.entry |> EChronicler.Models.JournalEntry.truncate_journal_entry_text() %>
+      </div>
+      <hr>
+
+</div>

--- a/lib/e_chronicler_web/views/error_view.ex
+++ b/lib/e_chronicler_web/views/error_view.ex
@@ -10,7 +10,8 @@ defmodule EChroniclerWeb.ErrorView do
   # By default, Phoenix returns the status message from
   # the template name. For example, "404.html" becomes
   # "Not Found".
-  def template_not_found(template, _assigns) do
-    Phoenix.Controller.status_message_from_template(template)
+
+  def render("500.html", _assigns) do
+    "Internal Server Error"
   end
 end

--- a/test/e_chronicler/journal_entries_test.exs
+++ b/test/e_chronicler/journal_entries_test.exs
@@ -5,12 +5,6 @@ defmodule EChronicler.JournalEntriesTest do
   alias EChronicler.JournalEntries
   alias EChronicler.Models.JournalEntry
 
-  test "list_journal_entries/0 returns all journal_entries" do
-    {:ok, journal_entry_one} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Bob", title: "Hello", entry: "Test."})
-    {:ok, journal_entry_two} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Betty", title: "Goodbye", entry: "Test."})
-    assert JournalEntries.list_journal_entries() == [journal_entry_two, journal_entry_one]
-  end
-
   test "list_journal_entries/0 lists journal entries in reverse chronological order from date, time, and microsecond of entry" do
     {:ok, journal_entry_1} = JournalEntry.create_journal_entry(%{author: "Tiny", title: "1", entry: "1"})
     {:ok, journal_entry_2} = JournalEntry.create_journal_entry(%{author: "Tiny", title: "2", entry: "2"})

--- a/test/e_chronicler/models/journal_entry_test.exs
+++ b/test/e_chronicler/models/journal_entry_test.exs
@@ -14,7 +14,6 @@ defmodule EChronicler.Models.JournalEntryTest  do
     assert JournalEntry.format_datetime(incorrect_datetime)  == "no date found"
   end
 
-
   test "truncate_journal_entry/1 truncates entry and adds ellipsis" do
     assert JournalEntry.truncate_journal_entry_text("Time is an illusion. Teatime doubly so. And time for tennis? Forget about it.") == "Time is an illusion. Teatime doubly so. And time fo..."
   end
@@ -27,5 +26,9 @@ defmodule EChronicler.Models.JournalEntryTest  do
     assert JournalEntry.truncate_journal_entry_text("") == ""
   end
 
+  test "get_journal_entry!/1 returns journal entry with corresponding id" do
+    {:ok, journal_entry} = JournalEntry.create_journal_entry(%{author: "Tiny", title: "1", entry: "1"})
+    assert JournalEntry.get_journal_entry!(journal_entry.id) == journal_entry
+  end
 
 end

--- a/test/e_chronicler/models/journal_entry_test.exs
+++ b/test/e_chronicler/models/journal_entry_test.exs
@@ -26,9 +26,13 @@ defmodule EChronicler.Models.JournalEntryTest  do
     assert JournalEntry.truncate_journal_entry_text("") == ""
   end
 
-  test "get_journal_entry!/1 returns journal entry with corresponding id" do
+  test "get_journal_entry/1 returns journal entry with corresponding id" do
     {:ok, journal_entry} = JournalEntry.create_journal_entry(%{author: "Tiny", title: "1", entry: "1"})
-    assert JournalEntry.get_journal_entry!(journal_entry.id) == journal_entry
+    assert JournalEntry.get_journal_entry(journal_entry.id) == journal_entry
+  end
+
+  test "get_journal_entry/1 with id that doesn't work returns nil" do
+    assert JournalEntry.get_journal_entry(6) == nil
   end
 
 end

--- a/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
+++ b/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
@@ -19,10 +19,15 @@ defmodule EChroniclerWeb.JournalEntryControllerTest do
 
   test "Single Journal Entry Is Displayed At /:id", %{conn: conn} do
     {:ok, journal_entry} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Bob", title: "Hello", entry: "Test."})
-    {:ok, _journal_entry_irrelevant} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Betty", title: "Goodbye", entry: "Test."})
+    {:ok, other_journal_entry} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Betty", title: "Goodbye", entry: "Test."})
     conn = get(conn, "/#{journal_entry.id}")
     assert html_response(conn, 200) =~ journal_entry.title
     refute html_response(conn, 200) =~ other_journal_entry.title
+  end
+
+  test "Return 404 if Entry Is Not Found at /:id", %{conn: conn} do
+    conn = get(conn, "/5")
+    assert html_response(conn, 404)
   end
 
 end

--- a/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
+++ b/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
@@ -21,8 +21,8 @@ defmodule EChroniclerWeb.JournalEntryControllerTest do
     {:ok, journal_entry} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Bob", title: "Hello", entry: "Test."})
     {:ok, _journal_entry_irrelevant} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Betty", title: "Goodbye", entry: "Test."})
     conn = get(conn, "/#{journal_entry.id}")
-    assert html_response(conn, 200) =~ "Hello"
-    assert !String.contains?(html_response(conn, 200), "Goodbye")
+    assert html_response(conn, 200) =~ journal_entry.title
+    refute html_response(conn, 200) =~ other_journal_entry.title
   end
 
 end

--- a/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
+++ b/test/e_chronicler_web/controllers/journal_entry_controller_test.exs
@@ -17,5 +17,12 @@ defmodule EChroniclerWeb.JournalEntryControllerTest do
     assert html_response(conn, 200) =~ "Supercilious"
   end
 
+  test "Single Journal Entry Is Displayed At /:id", %{conn: conn} do
+    {:ok, journal_entry} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Bob", title: "Hello", entry: "Test."})
+    {:ok, _journal_entry_irrelevant} = EChronicler.Models.JournalEntry.create_journal_entry(%{author: "Betty", title: "Goodbye", entry: "Test."})
+    conn = get(conn, "/#{journal_entry.id}")
+    assert html_response(conn, 200) =~ "Hello"
+    assert !String.contains?(html_response(conn, 200), "Goodbye")
+  end
 
 end

--- a/test/e_chronicler_web/views/error_view_test.exs
+++ b/test/e_chronicler_web/views/error_view_test.exs
@@ -5,7 +5,7 @@ defmodule EChroniclerWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.html" do
-    assert render_to_string(EChroniclerWeb.ErrorView, "404.html", []) == "Not Found"
+    assert render_to_string(EChroniclerWeb.ErrorView, "404.html", []) =~ "The page you are looking for could not be found. Sorry!"
   end
 
   test "renders 500.html" do


### PR DESCRIPTION
Add links on the index page to allow the user to click on each title and go to a page with a single entry. 

Added:

- One function `get_journal_entry!` to get a single journal entry by id in EChronicler.Models.JournalEntry
- a `show` function in the Journal Entry Controller to call one page
- a new line in the router
- links to each individual entry page on the Titles on the main page
- HTML file for individual pages

Tests:
- One test for `JournalEntry.get_journal_entry!` in `test/e_chronicler/models/journal_entry_test.exs`
- Two tests for individual journal entry pages in `test/e_chronicler_web/controllers/journal_entry_controller_test.exs`